### PR TITLE
[HTML5]: Replace deprecated Pointer_stringify function with UTF8ToString function calls

### DIFF
--- a/directories/src/extension_html5.cpp
+++ b/directories/src/extension_html5.cpp
@@ -131,8 +131,8 @@ static int download_file(lua_State *L) {
 		download_name = basename((char *)filename);
 	}
 	EM_ASM_({
-		var filename = Pointer_stringify($0);
-		var download_name = Pointer_stringify($1);
+		var filename = UTF8ToString($0);
+		var download_name = UTF8ToString($1);
 		var file;
 		var data = FS.readFile(filename).buffer;
 		var properties = {type: 'application/octet-stream'};


### PR DESCRIPTION
Pointer_stringify was deprecated and removed altogether at some point, these calls should be replaced with UTF8ToString